### PR TITLE
adding print styles and updating image paths for base url

### DIFF
--- a/february/index.html
+++ b/february/index.html
@@ -20,17 +20,17 @@
 <nav>
   <a href="..">&#10094;</a>
 </nav>
-<a href="http://codeforamerica.org"><img src="../img/CfA-Logo-White.png" id="logo"></a>
+<a href="http://codeforamerica.org"><img src="/img/CfA-Logo-White.png" id="logo"></a>
 
 <!-- header image -->
-<img src="../img/header_murals_innerglow2.jpg">
+<img src="/img/header_murals_innerglow2.jpg">
 <!-- /header image -->
 
 <!-- main content -->
 <div class="container">
   <h1>Reflections on February residency</h1>
   <p>We just wrapped up a whirlwind month in Richmond! We’re grateful to the many incredibly passionate people who have welcomed us to Richmond and shared their expertise in public health, civic technology, and community engagement.  Our 27 days included:</p>
-  <figure><img src="../img/the_team.jpg">With our city partners, Danny Avula (Richmond City Health District) and Andreas Addison (Civic Innovator, City of Richmond)</figure>
+  <figure><img src="/img/the_team.jpg">With our city partners, Danny Avula (Richmond City Health District) and Andreas Addison (Civic Innovator, City of Richmond)</figure>
   <table class="numbertable">
     <tr>
       <td>95</td><td>pages of Google doc notes</td>
@@ -53,19 +53,19 @@
   <h2>There’s still a huge insurance gap in Virginia</h2>
   <p>Because Virginia did not expand Medicaid coverage under the Affordable Care Act, about 195,000 people fall in the gap between the maximum income for Medicaid eligibility and the minimum income needed to qualify for a subsidized private insurance plan. Uninsured and underinsured people in Richmond navigate a network of charity care options with varying costs and eligibility criteria.</p>
   <h2>It’s hard to keep track of all the available services, hard to figure out what you’re eligible for, and hard to apply</h2>
-  <figure><img src="../img/flowchart_codeacross.jpg">CodeAcross attendees mapped out SNAP eligibility screening workflows.</figure>
+  <figure><img src="/img/flowchart_codeacross.jpg">CodeAcross attendees mapped out SNAP eligibility screening workflows.</figure>
   <p>The single most requested tool in our meetings was an up-to-date list of all available services for low-income people in Richmond. Because services change so quickly, existing resources like the statewide 211 system tend to have incomplete or out of date information. Eligibility criteria are often complex, and keeping track of all the documents needed to prove identity and income can be difficult. Patients often need to make an appointment for financial screening before they can receive care, or wait months to hear back after submitting an application. </p>
   <h2>Appointment scheduling is complicated</h2>
   <p>Making appointments often requires calling multiple offices to compare wait times, and keeping appointments can be difficult for people who have inconsistent work hours, unreliable transportation, and generally stressful lives. Patients want walk-in options, and many clinics provide them, but when demand exceeds capacity, people start lining up before sunrise and some are turned away.</p>
   <h2>Mental health is fundamental, but care is often difficult to access</h2>
-  <aside><img src="../img/sam_frances.jpg">Sam shadowing Frances, a social worker at Bon Secours Community Hospital</aside>
+  <aside><img src="/img/sam_frances.jpg">Sam shadowing Frances, a social worker at Bon Secours Community Hospital</aside>
   <p>Mental health problems can prevent people from accessing other health services or following doctors’ instructions, and they’re the number one reason for ambulance calls in Richmond. But only a few care options exist for people without insurance, and accessing them can require waiting months for an appointment. </p>
   <h2>For some, the ER is a better option than primary care</h2>
   <p>At a typical primary care clinic, there’s a two month wait for an appointment, each visit will cost $20, and you’ll need to go in for a financial screening before you can see a doctor. At the ER, you can walk in whenever you want and the visit will be free (the hospital will send bills later, but if you’re not concerned about your credit, you might ignore them). Plus, your family has been going to the ER for routine care your whole life, so the providers there are familiar. Where would you rather go?</p>
   <h2>Service providers struggle to communicate with each other efficiently</h2>
   <p>If a patient arrives at the emergency department of a hospital, the doctors there have information about the patient’s medical history at that hospital, but if the patient can’t tell them, they don’t know if the patient was seen recently at the city’s other health systems. They might order a test the patient already had done, or prescribe medications the patient is already taking. A clinic may refer a patient to a specialist, but not know whether the patient was ever seen. Nearly every clinician we met told us that electronic health record (EHR) systems “don’t talk to each other” and that this makes it more difficult for them to care for patients.  </p>
 </div>
-<figure><img src="../img/pcmh_ben_emma.jpg">Emma and Ben discussing project ideas with the Greater Richmond Patient Centered Medical Home Collaborative&nbsp;&nbsp;</figure>
+<figure><img src="/img/pcmh_ben_emma.jpg">Emma and Ben discussing project ideas with the Greater Richmond Patient Centered Medical Home Collaborative&nbsp;&nbsp;</figure>
 <div class="container">
   <h2>Richmond’s community health advocate program has huge potential</h2>
   <p>The Richmond City Health District runs a program that includes eight community health advocates (CHAs): two in schools and one in each of the six public housing complexes.  CHAs are members of those communities who connect their neighbors with health care resources and promote wellness. Their work includes helping with applications for services, informal counseling, organizing support groups and exercise groups, and much more.  From our meetings with CHAs and others in the public health field in Richmond, it’s clear that their work is incredibly helpful to their communities. As the city looks to expand the program, it’s important to be able to measure its impact.</p>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <p>We build open source technology and organize a network of people dedicated to improving government services. You can contact <a href="http://codeforamerica.org/people/ben-golder/">Ben Golder</a>, <a href="http://codeforamerica.org/people/emma-smithayer">Emma Smithayer</a>, or <a href="http://codeforamerica.org/people/sam-matthews">Sam Matthews</a> at <a href="mailto:richmond@codeforamerica.org">richmond@codeforamerica.org</a>.</p>
     <p><strong>Learn more about our work:</strong></p>
     <ul>
-      <li><a href="february/">February Reflections</a></li>
+      <li><a href="/february/">February Reflections</a></li>
     </ul>
   </div>
 

--- a/static/rva.css
+++ b/static/rva.css
@@ -120,3 +120,20 @@ nav a {
   top:10px;
   right:10px;
 }
+
+/* these styles are used only for printing */
+@media print {
+  html,
+  .numbertable td,
+  .numbertable td:first-child { font-size:14px; }
+  body { 
+    background-color:white;
+    line-height:1.4rem;
+  }
+  h1 { margin-top:30px; }
+  p { max-width:40rem; }
+  h2 { font-size:1.1rem; }
+  figure, aside, nav, img { display:none; }
+  footer { background-color:white; }
+  footer p { color:black; }
+}


### PR DESCRIPTION
### What Changed
- new `@media print { ... }` styles that remove images and shrink text size for print only, #9 
- all `../img/...` paths are now `/img/...` since we have a root URL at `rva.codeforamerica.org`
