### PR TITLE
adding rss feed for pages, relates to #19

### DIFF
--- a/february/index.html
+++ b/february/index.html
@@ -3,6 +3,8 @@ layout: default
 title: February Reflections
 weight: 1
 header_img: 'header_murals_innerglow2.jpg'
+date: Thursday, 5 Mar 2015
+excerpt: We just wrapped up a whirlwind month in Richmond! We’re grateful to the many incredibly passionate people who have welcomed us to Richmond and shared their expertise in public health, civic technology, and community engagement.
 ---
 
 <!-- main content -->

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,27 @@
+---
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>{{ site.name | xml_escape }}</title>
+    <description>{% if site.description %}{{ site.description | xml_escape }}{% endif %}</description>    
+    <link>http://rva.codeforamerica.org/</link>
+    <atom:link href="http://rva.codeforamerica.org/feed.xml" rel="self" type="application/rss+xml" />
+    
+    {% for weight in (1..10) %}{% for p in site.pages %}{% if p.weight == weight %}
+      <item>
+        <title>{{ p.title | xml_escape }}</title>
+          <dc:creator>Team RVA</dc:creator>
+        {% if p.excerpt %}
+          <description>{{ p.excerpt | xml_escape }}</description>
+        {% else %}
+          <description>{{ p.content | xml_escape }}</description>
+        {% endif %}
+        <pubDate>{{ p.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+        <link>http://rva.codeforamerica.org{{ p.url }}</link>
+        <guid isPermaLink="true">http://rva.codeforamerica.org{{ p.url }}</guid>
+      </item>
+    {% endif %}{% endfor %}{% endfor %}
+
+  </channel>
+</rss>


### PR DESCRIPTION
### What Changed
- new `feed.xml` builds off of the page `weight` specified in the YAML.
- pages will require a `date` and `excerpt` in their YAML now - #18 will require some updates
